### PR TITLE
README: Include settings folder for editable files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ New functions include:
 
 The Bluesky Crossposter is a python script that when running will automatically post your bluesky-posts to mastodon and twitter, excluding responses and reposts. The script can handle threads, quote posts of your own posts, and image posts, including alt text on images. 
 
-To get started, get the necessary keys and passwords and enter them in auth.py. Then fill in your paths in path.py. Finally set up a way for the code to be run periodically, for example a cronjob running every five or ten minutes.
+To get started, get the necessary keys and passwords and enter them in settings/auth.py. Then fill in your paths in settings/path.py. Finally set up a way for the code to be run periodically, for example a cronjob running every five or ten minutes.
 
-When first run, or run without a database file, all posts within the timelimit set by postTimeLimit in settings.py will be posted.
+When first run, or run without a database file, all posts within the timelimit set by postTimeLimit in settings/settings.py will be posted.
 
 In the settings.py you can also disable posting to twitter or mastodon if you only want to post to one of them. Just change "True" to "False" for the service you want to disable. You can also disable logging if you have limited space where the program will run.
 


### PR DESCRIPTION
Specify that the auth, paths, and settings files are in the settings folder.