### PR TITLE
Pin Python docker version to fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use latest alpine-derived Python base image
-FROM python:latest
+FROM python:3.12
 
 # Move to app directory
 


### PR DESCRIPTION
`python:latest` tag currently points to Python 3.13, which is newer than what the required atproto library currently supports.

Building docker image from `python:latest` results in an error:

```
3.918 ERROR: Ignored the following versions that require a different python version: 0.0.10 Requires-Python >=3.7,<3.12; 0.0.11 Requires-Python >=3.7,<3.12; 0.0.12 Requires-Python >=3.7,<3.12; 0.0.13 Requires-Python >=3.7,<3.12; 0.0.14 Requires-Python >=3.7,<3.12; 0.0.15 Requires-Python >=3.7,<3.12; 0.0.16 Requires-Python >=3.7,<3.12; 0.0.17 Requires-Python >=3.7,<3.12; 0.0.18 Requires-Python >=3.7,<3.12; 0.0.19 Requires-Python >=3.7,<3.12; 0.0.20 Requires-Python >=3.7,<3.12; 0.0.21 Requires-Python >=3.7,<3.12; 0.0.22 Requires-Python >=3.7,<3.12; 0.0.23 Requires-Python >=3.7,<3.12; 0.0.24 Requires-Python >=3.7,<3.12; 0.0.25 Requires-Python >=3.7,<3.12; 0.0.26 Requires-Python >=3.7.1,<3.12; 0.0.27 Requires-Python >=3.7.1,<3.12; 0.0.28 Requires-Python >=3.7.1,<3.12; 0.0.29 Requires-Python >=3.7.1,<3.12; 0.0.30 Requires-Python >=3.7.1,<3.13; 0.0.31 Requires-Python >=3.7.1,<3.13; 0.0.32 Requires-Python >=3.7.1,<3.13; 0.0.33 Requires-Python >=3.7.1,<3.13; 0.0.34 Requires-Python >=3.7.1,<3.13; 0.0.35 Requires-Python >=3.7.1,<3.13; 0.0.36 Requires-Python >=3.7.1,<3.13; 0.0.37 Requires-Python >=3.7.1,<3.13; 0.0.38 Requires-Python >=3.7.1,<3.13; 0.0.39 Requires-Python >=3.7.1,<3.13; 0.0.40 Requires-Python >=3.7.1,<3.13; 0.0.41 Requires-Python >=3.7.1,<3.13; 0.0.42 Requires-Python >=3.7.1,<3.13; 0.0.43 Requires-Python >=3.7.1,<3.13; 0.0.44 Requires-Python >=3.7.1,<3.13; 0.0.45 Requires-Python >=3.7.1,<3.13; 0.0.46 Requires-Python <3.13,>=3.7.1; 0.0.47 Requires-Python <3.13,>=3.8; 0.0.48 Requires-Python <3.13,>=3.8; 0.0.49 Requires-Python <3.13,>=3.8; 0.0.50 Requires-Python <3.13,>=3.8; 0.0.51 Requires-Python <3.13,>=3.8; 0.0.52 Requires-Python <3.13,>=3.8; 0.0.53 Requires-Python <3.13,>=3.8; 0.0.54 Requires-Python <3.13,>=3.8; 0.0.6 Requires-Python >=3.7,<3.12; 0.0.7 Requires-Python >=3.7,<3.12; 0.0.8 Requires-Python >=3.7,<3.12; 0.0.9 Requires-Python >=3.7,<3.12
```

Pinning version to 3.12 as supported by the library fixes the build.