### PR TITLE
Allows for using self-hosted BlueSky PDS

### DIFF
--- a/settings/auth.py
+++ b/settings/auth.py
@@ -5,6 +5,9 @@ import os
 BSKY_HANDLE = ""
 # Generate an app password in the settings on bluesky. DO NOT use your main password.
 BSKY_PASSWORD = ""
+# Your bluesky PDS if you are not using the main instance.
+# Setting this value to None means that the _BASE_API_URL_ ('https://bsky.social') will be used.
+BSKY_PDS = None
 # Your mastodon handle. Not needed for authentication, but used for making "quote posts".
 MASTODON_HANDLE = ""
 # The mastodon instance your account is on.
@@ -22,6 +25,7 @@ TWITTER_ACCESS_TOKEN_SECRET = ""
 # Override settings with environment variables if they exist
 BSKY_HANDLE = os.environ.get('BSKY_HANDLE') if os.environ.get('BSKY_HANDLE') else BSKY_HANDLE
 BSKY_PASSWORD = os.environ.get('BSKY_PASSWORD') if os.environ.get('BSKY_PASSWORD') else BSKY_PASSWORD
+BSKY_PDS = os.environ.get('BSKY_PDS') if os.environ.get('BSKY_PDS') else BSKY_PDS
 MASTODON_INSTANCE = os.environ.get('MASTODON_INSTANCE') if os.environ.get('MASTODON_INSTANCE') else MASTODON_INSTANCE
 MASTODON_HANDLE = os.environ.get('MASTODON_HANDLE') if os.environ.get('MASTODON_HANDLE') else MASTODON_HANDLE
 MASTODON_TOKEN = os.environ.get('MASTODON_TOKEN') if os.environ.get('MASTODON_TOKEN') else MASTODON_TOKEN


### PR DESCRIPTION
Hello,

Thank you for your script. It was super cool to find it, and it helped me to set up a cross post from Bluesky (@eric.coissac.eu) to Mastodon (eric@petite-maison-orange.fr).

Nevertheless, I was stuck at first because I'm using a self-hosted PDS.

I propose here a patch to your script that allows for specifying a PDS address through the `BSKY_PDS` environment variable. The variable must contain the fully qualified address : `https://my_pds.my_domain.me`, if you are relying on a non-standard server. Otherwise, it has just to be undefined or defined as blank to connect to the default Bluesky server, as defined in the `atproto` python package.  

All the best

Eric