### PR TITLE
make docker compose image lowercase

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
   crossposter:
     build: .
-    image: ghcr.io/Linus2punkt0/bluesky-crossposter:latest
+    image: ghcr.io/linus2punkt0/bluesky-crossposter:latest
     restart: always
     environment:
       BSKY_HANDLE:


### PR DESCRIPTION
getting error on mac m3:
```
unable to get image 'ghcr.io/Linus2punkt0/bluesky-crossposter:latest': Error response from daemon: invalid reference format: repository name (Linus2punkt0/bluesky-crossposter) must be lowercase
```