### PR TITLE
Disable wait_on_rate_limit for twitter

### DIFF
--- a/main/connections.py
+++ b/main/connections.py
@@ -50,7 +50,7 @@ def twitter_client_connect():
                         consumer_secret=TWITTER_APP_SECRET,
                         access_token=TWITTER_ACCESS_TOKEN,
                         access_token_secret=TWITTER_ACCESS_TOKEN_SECRET,
-                        wait_on_rate_limit=True)
+                        wait_on_rate_limit=False)
     
     return twitter_client
 


### PR DESCRIPTION
The wait_on_rate_limit option for tweepy is having unforseen consequences, and will be disabled until I can find a solution.