### PR TITLE
fix: safely check for not_found attribute on PostView (issue #129)

### DIFF
--- a/input/bluesky.py
+++ b/input/bluesky.py
@@ -85,7 +85,7 @@ def get_posts():
         # Checking if post is regular reply
         if status.post.record.reply:
             reply_id = status.post.record.reply.parent.cid
-            if status.reply.parent.not_found:
+            if getattr(status.reply.parent, 'not_found', False):
                 logger.info(f"Parent status {reply_id} seems to be deleted. Skipping post.")
                 continue
             # Poster will try to fetch reply to-username the "ordinary" way, 


### PR DESCRIPTION
## Summary

Fixes `AttributeError: 'PostView' object has no attribute 'not_found'` when processing replies to deleted posts.

## Problem

Commit `1b6f008` added a check for `status.reply.parent.not_found` to skip replies to deleted parent posts. However, the `PostView` object in the current AT Protocol SDK does not have a `not_found` attribute, causing an `AttributeError` when processing any reply post.

## Fix

Use `getattr()` with a default value of `False` to safely check for the attribute. This handles both cases:
- When `not_found` exists (returns its value)
- When `not_found` doesn't exist (returns `False`, allowing normal processing to continue)

## Testing

Verified the fix handles both scenarios:
- Posts with existing parent posts: processed normally
- Posts where `not_found` attribute is missing: processed without error