### PR TITLE
fix: escape quotes in f-string to fix SyntaxError (issue #131)

### DIFF
--- a/main/functions.py
+++ b/main/functions.py
@@ -72,7 +72,7 @@ def split_text(text, service):
     # Twitter has some over eager URL handling that needs to be accounted for
     potential_urls = re.findall(r" [a-z0-9.]*\.[a-z0-9]{2,30}[.,!?]{0,3} ", f" {text.lower()} ")
     if service == "twitter" and potential_urls:
-        logger.info(f"Found following strings that Twitter might interpret as URLS: {", ".join(potential_urls)}")
+        logger.info(f"Found following strings that Twitter might interpret as URLS: {', '.join(potential_urls)}")
         urls = find_mistaken_urls(potential_urls, service)
     if check_length(text, service, urls):
         return [text]


### PR DESCRIPTION
## Summary

Fix f-string syntax error in main/functions.py line 75.

**Before:**
```python
logger.info(f"Found following strings that Twitter might interpret as URLS: {", ".join(potential_urls)}")
```

**After:**
```python
logger.info(f"Found following strings that Twitter might interpret as URLS: {', '.join(potential_urls)}")
```

The inner quotes were not properly escaped, causing a SyntaxError in Python 3.12+.

## Testing

Verified syntax with `python3 -m py_compile main/functions.py` ✅

## Related Issue

Fixes #131