### PR TITLE
Further fix f-string syntax from #132 (fully fixes #131 for me)

### DIFF
--- a/main/functions.py
+++ b/main/functions.py
@@ -196,7 +196,7 @@ def check_length(string, service, urls):
     string_length = len(string)
     for url in urls:
         if url["url"] in string.lower():
-            logger.debug(f"Accounting for delta of {url["delta"]} caused by {url["url"]}")
+            logger.debug(f"Accounting for delta of {url['delta']} caused by {url['url']}")
             string_length += url["delta"]
     for character in service_parameters[service]["spec_chars"]:
         instances = string.count(character["char"])

--- a/main/functions.py
+++ b/main/functions.py
@@ -72,7 +72,7 @@ def split_text(text, service):
     # Twitter has some over eager URL handling that needs to be accounted for
     potential_urls = re.findall(r" [a-z0-9.]*\.[a-z0-9]{2,30}[.,!?]{0,3} ", f" {text.lower()} ")
     if service == "twitter" and potential_urls:
-        logger.info(f"Found following strings that Twitter might interpret as URLS: {", ".join(potential_urls)}")
+        logger.info(f"Found following strings that Twitter might interpret as URLS: {', '.join(potential_urls)}")
         urls = find_mistaken_urls(potential_urls, service)
     if check_length(text, service, urls):
         return [text]

--- a/main/post.py
+++ b/main/post.py
@@ -65,15 +65,15 @@ class Post():
             filename = ''.join(random.choice(string.ascii_lowercase) for i in range(10))
             # Attempting to get the correct file ending from the image url. 
             # This is not strictly necessary so if it fails the image is downloaded with no file ending.
-            file_ending = f".{image["url"].split("?")[0].split(".")[-1]}"
+            file_ending = f".{image['url'].split('?')[0].split('.')[-1]}"
             if len(file_ending) > 5:
-                file_ending = f".{file_ending.split("@")[-1]}"
+                file_ending = f".{file_ending.split('@')[-1]}"
             if len(file_ending) > 5:
                 file_ending = ""
             filename = f"{image_path}{filename}{file_ending}" 
-            logger.info(f"Downloading image from {image["url"]} as {filename}")
+            logger.info(f"Downloading image from {image['url']} as {filename}")
             # Downloading fullsize version of image
-            urllib.request.urlretrieve(image["url"], filename)
+            urllib.request.urlretrieve(image['url'], filename)
             # Checking the image type, mostly to see if it is a gif.
             local_image = Image.open(filename)
             # Saving image info in a dictionary and adding it to the list.

--- a/output/bluesky.py
+++ b/output/bluesky.py
@@ -132,7 +132,7 @@ def post(item):
             media = []
         # Posting regular post (might include media as an embed)
         else:
-            logger.info(f"bluesky_client.send_post({bluesky_post},reply_to={reply_to},labels={labels},langs={item["post"].info["language"]}")
+            logger.info(f"bluesky_client.send_post({bluesky_post},reply_to={reply_to},labels={labels},langs={item['post'].info['language']}")
             reply_ref = models.create_strong_ref(
                 bluesky_client.send_post(
                     bluesky_post,

--- a/output/bluesky.py
+++ b/output/bluesky.py
@@ -95,7 +95,7 @@ def post(item):
                 else:
                     image_alts.append(media_item["alt"])
                 aspect_ratios.append(get_aspect_ratio(media_item["filename"], "image"))
-            logger.debug(f"bluesky_client.send_images({bluesky_post}, images={media}, image_alts={image_alts}, image_aspect_ratios={aspect_ratios},labels={labels},langs={item["post"].info["language"]},reply_to={reply_to})")
+            logger.debug(f"bluesky_client.send_images({bluesky_post}, images={media}, image_alts={image_alts}, image_aspect_ratios={aspect_ratios},labels={labels},langs={item['post'].info['language']},reply_to={reply_to})")
             reply_ref = models.create_strong_ref(
                             bluesky_client.send_images(
                                 bluesky_post,
@@ -117,7 +117,7 @@ def post(item):
             with open(video_data["filename"], 'rb') as f:
                 video = f.read()
             aspect_ratio = get_aspect_ratio(video_data["filename"], "video")
-            logger.debug(f"bluesky_client.send_video({bluesky_post},video={video},video_alt={video_data['alt']},video_aspect_ratio={aspect_ratio},labels={labels},langs={item["post"].info["language"]})")
+            logger.debug(f"bluesky_client.send_video({bluesky_post},video={video},video_alt={video_data['alt']},video_aspect_ratio={aspect_ratio},labels={labels},langs={item['post'].info['language']})")
             reply_ref = models.create_strong_ref(
                         bluesky_client.send_video(
                             bluesky_post,

--- a/output/mastodon.py
+++ b/output/mastodon.py
@@ -80,7 +80,7 @@ def post(item):
         # API won't handle leading spaces. Tricking it by replacing the first leading space with a no-break space.
         if text_post.startswith(" "):
             text_post = text_post.replace(" ", "\u00A0", 1)
-        logger.debug(f"mastodon_client.status_post({text_post}, in_reply_to_id={reply_to_post}, media_ids={media_ids}, visibility={visibility}, language={language}), sensitive={item["post"].info["sensitive"]}")
+        logger.debug(f"mastodon_client.status_post({text_post}, in_reply_to_id={reply_to_post}, media_ids={media_ids}, visibility={visibility}, language={language}), sensitive={item['post'].info['sensitive']}")
         a = mastodon_client.status_post(text_post, in_reply_to_id=reply_to_post, media_ids=media_ids, visibility=visibility, language=language, sensitive=item["post"].info["sensitive"])
         logger.debug(a)
         reply_to_post = a["id"]


### PR DESCRIPTION
ISSUE FIXED:
 - f-string nested quotes need escaping, or swapping single for double (or vice-versa)

Building on @Jah-yee's PR #132 to my issue #131, more fixes were needed to bring this to a working state for me. Many thanks to them for root-causing it, I was able to fix up the rest that were needed.

Tested working on Raspberry Pi OS 5.x (Debian 12 Bookworm), with Python 3.11.2.

Succeeded cross-posting 2 Mastodon Toots -> 3 BSky posts (1 split to 2, 1 direct x-post). No warnings. Only [INFO] and [DEBUG] outputs that all show the expected progress.

As well as the files that have been modified, I checked all .py files in `/main/` and `/output/`, including `twitter.py` but found none there to clean up. I don't use Twitter so can't GUARANTEE `twitter.py` is working on 3.11.2, but I don't see a reason it shouldn't.

Fixes #131, subsumes #132 