### PR TITLE
Fix reversed thread order by preserving sub-second timestamps when sorting

### DIFF
--- a/input/bluesky.py
+++ b/input/bluesky.py
@@ -29,11 +29,13 @@ def get_posts():
             continue
         # Checking if the post has "indexe_at" set, meaning it is a repost.
         repost = False
-        created_at = get_date(status.post.record.created_at.split(".")[0])
+        raw_created_at = status.post.record.created_at
+        created_at = get_date(raw_created_at.split(".")[0])
         logger.debug(f'Post created at: {created_at}')
         if hasattr(status.reason, "indexed_at"):
             repost = True
-            created_at = get_date(status.reason.indexed_at.split(".")[0])
+            raw_created_at = status.reason.indexed_at
+            created_at = get_date(raw_created_at.split(".")[0])
         # Checking if post is outside time limit
         if not created_at > database.get_post_time_limit():
             logger.info(f'Post {post_id} posted outside time limit.')
@@ -162,11 +164,12 @@ def get_posts():
             "language": status.post.record.langs,
             "privacy": privacy_setting,
             "repost": repost,
-            "created_at": created_at
+            "created_at": created_at,
+            "raw_created_at": raw_created_at
         }
         logger.debug(post_info)
         posts.append(post_info)
-    posts = sorted(posts, key=lambda d: d['created_at'])
+    posts = sorted(posts, key=lambda d: d['raw_created_at'])
     post_dict = {}
     for post in posts:
         post_dict[post["post_id"]] = Post(post)


### PR DESCRIPTION
## Problem

When a thread is published in a single action via Bluesky's composer, all posts share the same `created_at` down to the second, differing only in sub-second precision (e.g. `…16.663`, `.664`, `.665`).

In `get_posts()`, the timestamp is truncated with `.split(".")[0]` before parsing, discarding the fraction. The queue is then sorted with `sorted(posts, key=lambda d: d['created_at'])`. Because the keys are now identical and Python's sort is stable, posts keep the order `get_author_feed` returns — newest-first — so the thread ends up queued in reverse (replies before root).

The Mastodon output module skips any reply whose parent hasn't been crossposted yet, so only the root posts on the first polling cycle, the next segment on the following cycle, and so on — one segment per cycle instead of the whole thread at once.

## Fix

Preserve the raw ISO-8601 timestamp and sort on that instead. The truncated `created_at` is left untouched, because `get_date()` parses with the format `YYYY-MM-DDTHH:mm:ss` and does not accept fractional seconds (it's also used for the time-limit comparison against the database). ISO-8601 strings sort correctly lexicographically, so ordering is restored without changing any date parsing.

- Capture `raw_created_at` (from `record.created_at`, or `reason.indexed_at` for reposts)
- Carry it through in the post dict
- Sort the queue on `raw_created_at`

## Testing

Composed a 3-post thread in a single publish action on Bluesky. Before the fix, the segments crossposted one per polling cycle in reverse order; after, all three appear on Mastodon in the same cycle in the correct order, with no "has not been crossposted" thread-continuation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
